### PR TITLE
remove unnecessary use of QVairant, and make the example compatible w…

### DIFF
--- a/PandasTableView/PandasModel.py
+++ b/PandasTableView/PandasModel.py
@@ -9,28 +9,28 @@ class PandasModel(QtCore.QAbstractTableModel):
 
     def headerData(self, section, orientation, role=QtCore.Qt.DisplayRole):
         if role != QtCore.Qt.DisplayRole:
-            return QtCore.QVariant()
+            return None
 
         if orientation == QtCore.Qt.Horizontal:
             try:
                 return self._df.columns.tolist()[section]
             except (IndexError, ):
-                return QtCore.QVariant()
+                return None
         elif orientation == QtCore.Qt.Vertical:
             try:
                 # return self.df.index.tolist()
                 return self._df.index.tolist()[section]
             except (IndexError, ):
-                return QtCore.QVariant()
+                return None
 
     def data(self, index, role=QtCore.Qt.DisplayRole):
         if role != QtCore.Qt.DisplayRole:
-            return QtCore.QVariant()
+            return None
 
         if not index.isValid():
-            return QtCore.QVariant()
+            return None
 
-        return QtCore.QVariant(str(self._df.ix[index.row(), index.column()]))
+        return str(self._df.ix[index.row(), index.column()])
 
     def setData(self, index, value, role):
         row = self._df.index[index.row()]


### PR DESCRIPTION
The PandasTableView example wont work with the new official [PySide2 ](https://www.qt.io/qt-for-python)from The Qt Company, since it doesnt have QVariant. Its use isnt necessary anyways so simply removing it allows one to run the example with either PyQt5 or PYSide2 simple by replacing 

`from PyQt5 import...` with `from PySide2 import`

and of course 
`pip install PySide2`

Would solve 
https://github.com/eyllanesc/stackoverflow/issues/7